### PR TITLE
JavaScript error when changing tracker

### DIFF
--- a/app/views/issue_templates/_template_pulldown.html.erb
+++ b/app/views/issue_templates/_template_pulldown.html.erb
@@ -20,6 +20,7 @@
 </optgroup>
 <% if is_triggered_by.blank? || (is_triggered_by.present? && is_triggered_by == 'issue_tracker_id') %>
     <script type="text/javascript">
+    (function(){
         let load_url = '<%= url_for(controller: 'issue_templates', action: 'load', project_id: @project) %>';
         let should_replaced = '<%= should_replaced %>';
         let confirm_msg = "<%=h escape_javascript((l(:defaulf_template_loaded, tracker: @tracker))) %>";
@@ -29,5 +30,6 @@
 
         var templateNS = templateNS || new ISSUE_TEMPLATE();
         templateNS.load_template(load_url, confirm_msg, should_replaced, false, confirmation, general_text_Yes, general_text_No);
+    })();
     </script>
 <% end %>


### PR DESCRIPTION
If you change the tracker on the issue creation form, the issue template with the default settings will be displayed, but the setting values will not be displayed on the screen due to an error in JavaScript.

```
Uncaught SyntaxError: Identifier 'load_url' has already been declared
    at b (jquery-3.5.1-ui-1.12.1-ujs-5.2.3.js?1613355381:2)
    at Pe (jquery-3.5.1-ui-1.12.1-ujs-5.2.3.js?1613355381:2)
    at s.fn.init.append (jquery-3.5.1-ui-1.12.1-ujs-5.2.3.js?1613355381:2)
    at s.fn.init.<anonymous> (jquery-3.5.1-ui-1.12.1-ujs-5.2.3.js?1613355381:2)
    at $ (jquery-3.5.1-ui-1.12.1-ujs-5.2.3.js?1613355381:2)
    at s.fn.init.html (jquery-3.5.1-ui-1.12.1-ujs-5.2.3.js?1613355381:2)
    at Object.<anonymous> (issue_templates.js?1614134447:187)
    at c (jquery-3.5.1-ui-1.12.1-ujs-5.2.3.js?1613355381:2)
    at Object.fireWith [as resolveWith] (jquery-3.5.1-ui-1.12.1-ujs-5.2.3.js?1613355381:2)
    at l (jquery-3.5.1-ui-1.12.1-ujs-5.2.3.js?1613355381:2)
```

I think the cause is that the scope of the variable defined by let is global.
To solve this, I redefined it with an anonymous function.