### PR TITLE
Sort trackers in position order

### DIFF
--- a/app/controllers/global_issue_templates_controller.rb
+++ b/app/controllers/global_issue_templates_controller.rb
@@ -15,7 +15,7 @@ class GlobalIssueTemplatesController < ApplicationController
   # Action for global template : Admin right is required.
   #
   def index
-    trackers = Tracker.all
+    trackers = Tracker.sorted
     template_map = {}
     trackers.each do |tracker|
       tracker_id = tracker.id
@@ -135,7 +135,7 @@ class GlobalIssueTemplatesController < ApplicationController
   end
 
   def render_form_params
-    trackers = Tracker.all
+    trackers = Tracker.sorted
     projects = Project.all
     tracker_id = @global_issue_template.tracker_id
     custom_fields = core_fields_map_by_tracker_id(tracker_id: tracker_id)

--- a/app/controllers/global_note_templates_controller.rb
+++ b/app/controllers/global_note_templates_controller.rb
@@ -15,7 +15,7 @@ class GlobalNoteTemplatesController < ApplicationController
   # Action for global template : Admin right is required.
   #
   def index
-    trackers = Tracker.all
+    trackers = Tracker.sorted
     template_map = {}
     trackers.each do |tracker|
       tracker_id = tracker.id
@@ -94,7 +94,7 @@ class GlobalNoteTemplatesController < ApplicationController
   end
 
   def render_form_params
-    trackers = Tracker.all
+    trackers = Tracker.sorted
     projects = Project.all
 
     { layout: !request.xhr?,

--- a/test/functional/global_issue_templates_controller_test.rb
+++ b/test/functional/global_issue_templates_controller_test.rb
@@ -22,6 +22,23 @@ class GlobalIssueTemplatesControllerTest < Redmine::ControllerTest
     assert_response :success
   end
 
+  def test_get_index_should_sort_trackers_in_position_order
+    [
+      ['Feature request', 1],
+      ['Support request', 2],
+      ['Bug', 3],
+    ].each do |name, position|
+      tracker = Tracker.find_by(name: name)
+      tracker.position = position
+      tracker.save!(validate: false)
+    end
+    get :index
+    assert_response :success
+    assert_select 'div.template_box:nth-of-type(1) h3.template_tracker', 'Feature request'
+    assert_select 'div.template_box:nth-of-type(2) h3.template_tracker', 'Support request'
+    assert_select 'div.template_box:nth-of-type(3) h3.template_tracker', 'Bug'
+  end
+
   def test_update_template
     put :update, params: { id: 2, global_issue_template:
       { description: 'Update Test Global template2' } }


### PR DESCRIPTION
#4:
Trackers in Global issue templates and Global note templates do arrange in position order. However, I haven't created a test because the functional test file for GlobalNoteTemplatesControllerTest doesn't exist.