### PR TITLE
Change the key in the sr-YU language file

### DIFF
--- a/config/locales/sr-YU.yml
+++ b/config/locales/sr-YU.yml
@@ -1,5 +1,5 @@
 # English strings go here for Rails i18n
-sr:
+sr-YU:
   issue_templates: Šabloni problema
   issue_template: Šablon problema
   issue_template_note: nota


### PR DESCRIPTION
Probably due to the i18n gem version upgrade, the sr-YU language file fails to load when Redmine starts. (in Redmine trunk)
Fixing the key will make it work correctly.

```
I18n::InvalidFilenames (Found 1 error(s).
The first 1 error(s):
/var/lib/redmine/plugins/redmine_issue_templates/config/locales/sr-YU.yml can only load translations for "sr-YU". Found translations for: [:sr].

To use the LazyLoadable backend:
1. Filenames must start with the locale.
2. An underscore must separate the locale with any optional text that follows.
3. The file must only contain translation data for the single locale.

Example:
"/config/locales/fr.yml" which contains:
  fr:
    dog:
      chien
):
  
lib/redmine/i18n.rb:115:in `valid_languages'
lib/redmine/i18n.rb:141:in `find_language'
app/controllers/application_controller.rb:250:in `set_localization'
```