### PR TITLE
Add presence validation for NoteTemplate#tracker(0.3-stable)

### DIFF
--- a/app/models/note_template.rb
+++ b/app/models/note_template.rb
@@ -23,6 +23,7 @@ class NoteTemplate < ActiveRecord::Base
   validates :project_id, presence: true
   validates :name, uniqueness: { scope: :project_id }
   validates :name, presence: true
+  validates :tracker, presence: true
   acts_as_positioned scope: %i[project_id tracker_id]
 
   enum visibility: { mine: 0, roles: 1, open: 2 }

--- a/test/unit/note_template_test.rb
+++ b/test/unit/note_template_test.rb
@@ -81,4 +81,14 @@ class NoteTemplateTest < ActiveSupport::TestCase
     # Check error message.
     assert_equal 'Please select at least one role.', e.message
   end
+
+  def test_create_should_require_tracker
+    template = NoteTemplate.new(name: 'NoteTemplate1', project_id: 1, visibility: 'open')
+    assert_no_difference 'NoteTemplate.count' do
+      assert_raises ActiveRecord::RecordInvalid do
+        template.save!
+      end
+    end
+    assert_equal ['Tracker cannot be blank'], template.errors.full_messages
+  end
 end


### PR DESCRIPTION
#15:
I added presence validation for NoteTemplate#tracker. This will prevent raising Internal error exception.