### PR TITLE
Rename CircleCI test mysql user key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - image: mysql:5.7
         command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --innodb-large-prefix=true --innodb-file-format=Barracuda --sql-mode=""
         environment:
-          MYSQL_USER: root
+          MYSQL_ROOT_USER: root
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
 
     working_directory: ~/repo


### PR DESCRIPTION
#40 - CircleCI "test" job mysql connection error solved by renaming mysql image environment user key `MYSQL_USER` to `MYSQL_ROOT_USER`.

There were some test failures, but I will create another issue for that later.
```
#!/bin/bash -eo pipefail
bundle exec rake ${CIRCLE_PROJECT_REPONAME}:test RAILS_ENV=test

Run options: --seed 41859

# Running:

..........F

Failure:
IssueTemplatesControllerTest#test_preview_template [/home/circleci/repo/plugins/redmine_issue_templates/test/functional/issue_templates_controller_test.rb:120]:
  <p>h1. Test data.</p>
.
Expected 0 to be >= 1.


rails test plugins/redmine_issue_templates/test/functional/issue_templates_controller_test.rb:116

......................F

Failure:
IssueTemplatesSettingsControllerTest#test_preview_template_setting [/home/circleci/repo/plugins/redmine_issue_templates/test/functional/issue_templates_settings_controller_test.rb:56]:
  <p>h1. Preview test.</p>
.
Expected 0 to be >= 1.


rails test plugins/redmine_issue_templates/test/functional/issue_templates_settings_controller_test.rb:52

...................F

Failure:
GlobalIssueTemplatesControllerTest#test_preview_template [/home/circleci/repo/plugins/redmine_issue_templates/test/functional/global_issue_templates_controller_test.rb:115]:
  <p>h1. Global Test data.</p>
.
Expected 0 to be >= 1.


rails test plugins/redmine_issue_templates/test/functional/global_issue_templates_controller_test.rb:113

...................

Finished in 5.379917s, 13.5690 runs/s, 40.7069 assertions/s.
73 runs, 219 assertions, 3 failures, 0 errors, 0 skips
Coverage report generated for Functional Tests to /home/circleci/repo/coverage/redmine_issue_templates_test. 1077 / 1341 LOC (80.31%) covered.
rake aborted!
Command failed with status (1)
/home/circleci/repo/vendor/bundle/ruby/2.6.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => redmine_issue_templates:test
(See full trace by running task with --trace)

Exited with code exit status 1
CircleCI received exit code 1
```