### PR TITLE
Fix plugin information - author, URL etc.

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -45,12 +45,12 @@ end
 Redmine::Plugin.register :redmine_issue_templates do
   begin
     name 'Redmine Issue Templates plugin'
-    author 'Akiko Takano'
+    author 'Agileware Inc.'
     description 'Plugin to generate and use issue templates for each project to assist issue creation.'
     version '1.1.0'
-    author_url 'http://twitter.com/akiko_pusu'
+    author_url 'http://agileware.jp/'
     requires_redmine version_or_higher: '4.0'
-    url 'https://github.com/akiko-pusu/redmine_issue_templates'
+    url 'https://github.com/agileware-jp/redmine_issue_templates'
 
     settings partial: 'settings/redmine_issue_templates',
              default: {


### PR DESCRIPTION
The plugin information was still pointing to the original author and repository. Because Takano-san will not support it anymore (repository is archived), fixed the plugin information to point to the Agileware Inc. repository.