### PR TITLE
Improve sort order of note templates in pop-up dialog(0.3-stable)

### DIFF
--- a/app/controllers/note_templates_controller.rb
+++ b/app/controllers/note_templates_controller.rb
@@ -74,7 +74,7 @@ class NoteTemplatesController < ApplicationController
 
     note_templates = NoteTemplate.visible_note_templates_condition(
       user_id: User.current.id, project_id: project_id, tracker_id: tracker_id
-    )
+    ).sorted
     respond_to do |format|
       format.html do
         render action: '_list_note_templates',

--- a/app/views/note_templates/_list_note_templates.html.erb
+++ b/app/views/note_templates/_list_note_templates.html.erb
@@ -6,31 +6,30 @@
     <th><%=h l(:button_apply, default: 'Apply') %></th>
   </tr>
   </thead>
+  <tbody>
 <% note_templates.each do |template| %>
-      <tr class="<%= cycle('odd', 'even') %> template_data">
-        <td>
-          <%= template.name %>
-        </td>
-        <td>
-          <div class="template_tooltip_wrapper">
-            <a class="icon template_tooltip" href="#" title="<%= l(:label_preview) %>"></a>
-            <div class="wiki template_tooltip_body">
-              <span class="title"><%= template.name %></span>
-              <%= textilizable(template.description) %>
-              <hr/>
-              <span class="title"><%= l(:issue_template_note) %></span>
-              <%= textilizable(template.try(:memo)) %>
-            </div>
+    <tr class="<%= cycle('odd', 'even') %> template_data">
+      <td>
+        <%= template.name %>
+      </td>
+      <td>
+        <div class="template_tooltip_wrapper">
+          <a class="icon template_tooltip" href="#" title="<%= l(:label_preview) %>"></a>
+          <div class="wiki template_tooltip_body">
+            <span class="title"><%= template.name %></span>
+            <%= textilizable(template.description) %>
+            <hr/>
+            <span class="title"><%= l(:issue_template_note) %></span>
+            <%= textilizable(template.try(:memo)) %>
           </div>
-        </td>
-        <td>
-          <a data-note-template-id="<%= template.id %>"
-             href="#" onclick="applyNoteTemplate(this, <%= template.id %>);"
-             class="icon icon-test template-update-link"></a>
-        </td>
-      </tr>
+        </div>
+      </td>
+      <td>
+        <a data-note-template-id="<%= template.id %>"
+           href="#" onclick="applyNoteTemplate(this, <%= template.id %>);"
+           class="icon icon-test template-update-link"></a>
+      </td>
+    </tr>
 <% end %>
+  </tbody>
 </table>
-<script type="text/javascript">
-
-</script>

--- a/lib/issue_templates/journals_hook.rb
+++ b/lib/issue_templates/journals_hook.rb
@@ -34,7 +34,7 @@ module IssueTemplates
       (tracker_id, project_id) = tracker_project_ids(context, tracker_id)
       NoteTemplate.visible_note_templates_condition(
         user_id: User.current.id, project_id: project_id, tracker_id: tracker_id
-      )
+      ).sorted
     end
 
     def tracker_project_ids(context, tracker_id)


### PR DESCRIPTION
#47
Improved sort order of note templates in pop-up dialog, but RSpec testing is not working at this time. Hopefully pull request #50, an improved RSpec tests will be merged into the 0.3-stable branch first.