### PR TITLE
Improve sort order of note templates in pop-up dialog(master)

### DIFF
--- a/app/controllers/note_templates_controller.rb
+++ b/app/controllers/note_templates_controller.rb
@@ -90,7 +90,7 @@ class NoteTemplatesController < ApplicationController
 
     global_note_templates = GlobalNoteTemplate.visible_note_templates_condition(
       user_id: User.current.id, project_id: project_id, tracker_id: tracker_id
-    )
+    ).sorted
 
     respond_to do |format|
       format.html do

--- a/app/controllers/note_templates_controller.rb
+++ b/app/controllers/note_templates_controller.rb
@@ -86,7 +86,7 @@ class NoteTemplatesController < ApplicationController
 
     note_templates = NoteTemplate.visible_note_templates_condition(
       user_id: User.current.id, project_id: project_id, tracker_id: tracker_id
-    )
+    ).sorted
 
     global_note_templates = GlobalNoteTemplate.visible_note_templates_condition(
       user_id: User.current.id, project_id: project_id, tracker_id: tracker_id

--- a/app/views/note_templates/_list_note_templates.html.erb
+++ b/app/views/note_templates/_list_note_templates.html.erb
@@ -6,52 +6,54 @@
     <th><%=h l(:button_apply, default: 'Apply') %></th>
   </tr>
   </thead>
+  <tbody>
 <% note_templates.each do |template| %>
-      <tr class="<%= cycle('odd', 'even') %> template_data">
-        <td>
-          <%= template.name %>
-        </td>
-        <td>
-          <div class='template_tooltip_wrapper'>
-            <a class='icon template_tooltip' href='#' title='<%= l(:label_preview) %>'></a>
-            <div class='wiki template_tooltip_body'>
-              <span class='title'><%= template.name %></span>
-              <%= textilizable(template.description) %>
-              <hr/>
-              <span class='title'><%= l(:issue_template_note) %></span>
-              <%= textilizable(template.try(:memo)) %>
-            </div>
+    <tr class="<%= cycle('odd', 'even') %> template_data">
+      <td>
+        <%= template.name %>
+      </td>
+      <td>
+        <div class='template_tooltip_wrapper'>
+          <a class='icon template_tooltip' href='#' title='<%= l(:label_preview) %>'></a>
+          <div class='wiki template_tooltip_body'>
+            <span class='title'><%= template.name %></span>
+            <%= textilizable(template.description) %>
+            <hr/>
+            <span class='title'><%= l(:issue_template_note) %></span>
+            <%= textilizable(template.try(:memo)) %>
           </div>
-        </td>
-        <td>
-          <a data-note-template-id='<%= template.id %>'
-             onclick='noteTemplateNS.applyNoteTemplate(this)'
-             class='icon icon-test template-update-link'></a>
-        </td>
-      </tr>
+        </div>
+      </td>
+      <td>
+        <a data-note-template-id='<%= template.id %>'
+           onclick='noteTemplateNS.applyNoteTemplate(this)'
+           class='icon icon-test template-update-link'></a>
+      </td>
+    </tr>
 <% end %>
 <% global_note_templates.each do |template| %>
-      <tr class="<%= cycle('odd', 'even') %> template_data">
-        <td>
-          <%= template.name %>
-        </td>
-        <td>
-          <div class='template_tooltip_wrapper'>
-            <a class='icon template_tooltip' href='#' title='<%= l(:label_preview) %>'></a>
-            <div class='wiki template_tooltip_body'>
-              <span class='title'><%= template.name %></span>
-              <%= textilizable(template.description) %>
-              <hr/>
-              <span class='title'><%= l(:issue_template_note) %></span>
-              <%= textilizable(template.try(:memo)) %>
-            </div>
+    <tr class="<%= cycle('odd', 'even') %> template_data">
+      <td>
+        <%= template.name %>
+      </td>
+      <td>
+        <div class='template_tooltip_wrapper'>
+          <a class='icon template_tooltip' href='#' title='<%= l(:label_preview) %>'></a>
+          <div class='wiki template_tooltip_body'>
+            <span class='title'><%= template.name %></span>
+            <%= textilizable(template.description) %>
+            <hr/>
+            <span class='title'><%= l(:issue_template_note) %></span>
+            <%= textilizable(template.try(:memo)) %>
           </div>
-        </td>
-        <td>
-          <a data-note-template-id='<%= template.id %>'
-             onclick='noteTemplateNS.applyNoteTemplate(this)'
-             class='icon icon-test template-global template-update-link'></a>
-        </td>
-      </tr>
+        </div>
+      </td>
+      <td>
+        <a data-note-template-id='<%= template.id %>'
+           onclick='noteTemplateNS.applyNoteTemplate(this)'
+           class='icon icon-test template-global template-update-link'></a>
+      </td>
+    </tr>
 <% end %>
+  </tbody>
 </table>

--- a/lib/issue_templates/journals_hook.rb
+++ b/lib/issue_templates/journals_hook.rb
@@ -36,7 +36,7 @@ module IssueTemplates
       (tracker_id, project_id) = tracker_project_ids(context, tracker_id)
       NoteTemplate.visible_note_templates_condition(
         user_id: User.current.id, project_id: project_id, tracker_id: tracker_id
-      )
+      ).sorted
     end
 
     def global_note_templates(context, tracker_id)

--- a/lib/issue_templates/journals_hook.rb
+++ b/lib/issue_templates/journals_hook.rb
@@ -43,7 +43,7 @@ module IssueTemplates
       (tracker_id, project_id) = tracker_project_ids(context, tracker_id)
       GlobalNoteTemplate.visible_note_templates_condition(
         user_id: User.current.id, project_id: project_id, tracker_id: tracker_id
-      )
+      ).sorted
     end
 
     def tracker_project_ids(context, tracker_id)

--- a/spec/features/update_issue_spec.rb
+++ b/spec/features/update_issue_spec.rb
@@ -181,6 +181,48 @@ feature 'Update issue', js: true do
     end
   end
 
+  context 'Have multiple global note templates' do
+    background do
+      FactoryBot.rewind_sequences
+      FactoryBot.create_list(:global_note_template, 3,
+        tracker_id: tracker.id, visibility: :open, enabled: true, project_ids: [project.id]
+      )
+    end
+
+    scenario 'List of global template for note on popup should be in the correct order' do
+      template_list = GlobalNoteTemplate.visible_note_templates_condition(
+        user_id: user.id, project_id: project.id, tracker_id: tracker.id
+      ).sorted
+      expect(template_list.count).to eq 3
+
+      note_template = template_list.last
+      note_template.position = 1
+      note_template.save!
+      template_list.reload
+      #              id: 1, 2, 3    1, 2, 3
+      #--------------------------------------
+      # change position: 1, 2, 3 to 2, 3, 1
+
+      visit_update_issue(user)
+      issue = Issue.last
+      visit "/issues/#{issue.id}"
+      page.find('#content > div:nth-child(1) > a.icon.icon-edit').click
+      sleep(0.2)
+      expect(page).to have_selector('a#link_template_issue_notes_dialog')
+
+      page.find('a#link_template_issue_notes_dialog').click
+      wait_for_ajax
+
+      page.assert_selector('#template_issue_notes_dialog table.template_list tbody') do |node|
+        template_list.each.with_index(1) do |template, idx|
+          node.assert_selector(
+            "tr:nth-child(#{idx}) td:nth-child(3) a[class~='template-update-link'][class~='template-global'][data-note-template-id='#{template.id}']"
+          )
+        end
+      end
+    end
+  end
+
   private
 
   def visit_update_issue(user)

--- a/spec/features/update_issue_spec.rb
+++ b/spec/features/update_issue_spec.rb
@@ -93,6 +93,48 @@ feature 'Update issue', js: true do
     end
   end
 
+  context 'Have multiple note templates' do
+    background do
+      FactoryBot.rewind_sequences
+      FactoryBot.create_list(:note_template, 3,
+        project_id: project.id, tracker_id: tracker.id, visibility: :open, enabled: true
+      )
+    end
+
+    scenario 'List of template for note on popup should be in the correct order' do
+      template_list = NoteTemplate.visible_note_templates_condition(
+        user_id: user.id, project_id: project.id, tracker_id: tracker.id
+      ).sorted
+      expect(template_list.count).to eq 3
+
+      note_template = template_list.last
+      note_template.position = 1
+      note_template.save!
+      template_list.reload
+      #              id: 1, 2, 3    1, 2, 3
+      #--------------------------------------
+      # change position: 1, 2, 3 to 2, 3, 1
+
+      visit_update_issue(user)
+      issue = Issue.last
+      visit "/issues/#{issue.id}"
+      page.find('#content > div:nth-child(1) > a.icon.icon-edit').click
+      sleep(0.2)
+      expect(page).to have_selector('a#link_template_issue_notes_dialog')
+
+      page.find('a#link_template_issue_notes_dialog').click
+      wait_for_ajax
+
+      page.assert_selector('#template_issue_notes_dialog table.template_list tbody') do |node|
+        template_list.each.with_index(1) do |template, idx|
+          node.assert_selector(
+            "tr:nth-child(#{idx}) td:nth-child(3) a[class~='template-update-link'][data-note-template-id='#{template.id}']"
+          )
+        end
+      end
+    end
+  end
+
   context 'Have global note template' do
     given(:expected_note_description) { 'Global Note Template desctiption' }
     before do


### PR DESCRIPTION
#47
Improved sort order of note templates and global note templates in pop-up dialog, but RSpec testing is not working at this time. Hopefully pull request #51, an improved RSpec tests will be merged into the master branch first.