### PR TITLE
Display the ja locale text when global note text templates are empty

### DIFF
--- a/app/views/global_note_templates/index.html.erb
+++ b/app/views/global_note_templates/index.html.erb
@@ -30,7 +30,7 @@
           <th><%= l(:label_preview) %></th>
           <th class='hideable'><%= l(:field_tracker) %></th>
           <th class='hideable'><%= l(:field_author) %></th>
-          <th class='hideable'><%= l(:field_updated_at) %></th>
+          <th class='hideable'><%= l(:field_updated_on) %></th>
           <th><%= l(:label_enabled) %></th>
           <th><%=l(:button_sort)%></th>
         </tr>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -38,6 +38,7 @@ ja:
   label_should_replaced_help_message: "オプションをチェックすると、テンプレートを適用する際に、入力済みの本文とタイトルを上書きします。（デフォルトはOFFです）"
   global_issue_templates: "グローバル チケットテンプレート"
   no_issue_templates_for_this_redmine: "このRedmineにはグローバルチケットテンプレートは定義されていません。"
+  no_note_templates_for_this_redmine: "このRedmineにはグローバルコメント用テンプレートは定義されていません。"
   only_admin_can_associate_global_template: "このプロジェクトでグローバルチケットテンプレートを利用するには、Redmine管理者権限が必要です。"
   text_no_tracker_enabled_for_global: "テンプレートはトラッカー毎に設定します。\nトラッカーの設定をお願いします。"
   display_and_filter_issue_templates_in_dialog: "テンプレートの内容を確認"


### PR DESCRIPTION
Regarding `no_note_templates_for_this_redmine`, I believe we should have prepared a string for each language. However, as there are many languages and it would be too difficult to handle, we have prepared translations only for Japanese and set the default text in English for all other languages.