### PR TITLE
Hide disabled (global) note templates

### DIFF
--- a/app/models/global_note_template.rb
+++ b/app/models/global_note_template.rb
@@ -130,7 +130,7 @@ class GlobalNoteTemplate < ActiveRecord::Base
 
       # return uniq ids
       ids = open_ids | role_ids
-      GlobalNoteTemplate.where(id: ids).includes(:global_note_visible_roles)
+      GlobalNoteTemplate.where(id: ids).enabled.includes(:global_note_visible_roles)
     end
 
     def get_templates_for_project_tracker(project_id, tracker_id = nil)

--- a/app/models/note_template.rb
+++ b/app/models/note_template.rb
@@ -127,7 +127,7 @@ class NoteTemplate < ActiveRecord::Base
 
       # return uniq ids
       ids = open_ids | mine_ids | role_ids
-      NoteTemplate.where(id: ids).includes(:note_visible_roles)
+      NoteTemplate.where(id: ids).enabled.includes(:note_visible_roles)
     end
   end
 end

--- a/spec/features/update_issue_spec.rb
+++ b/spec/features/update_issue_spec.rb
@@ -132,6 +132,31 @@ feature 'Update issue', js: true do
         end
       end
     end
+
+  end
+
+  context 'Have disabled note templates' do
+    background do
+      FactoryBot.rewind_sequences
+      FactoryBot.create_list(
+        :note_template, 3, project_id: project.id, tracker_id: tracker.id, visibility: :open, enabled: false
+      )
+    end
+
+    scenario 'Disabled Templates would not to be shown.' do
+      template_list = NoteTemplate.visible_note_templates_condition(
+        user_id: user.id, project_id: project.id, tracker_id: tracker.id
+      )
+      expect(template_list).to be_empty
+
+      visit_update_issue(user)
+      issue = Issue.last
+      visit "/issues/#{issue.id}"
+
+      page.find('#content > div:nth-child(1) > a.icon.icon-edit').click
+      sleep(0.2)
+      expect(page).to have_no_selector('a#link_template_issue_notes_dialog')
+    end
   end
 
   context 'Have global note template' do
@@ -219,6 +244,29 @@ feature 'Update issue', js: true do
           )
         end
       end
+    end
+  end
+
+  context 'Have disabled global note templates' do
+    before do
+      Setting.send 'plugin_redmine_issue_templates=', 'apply_global_template_to_all_projects' => 'true'
+      create_list(
+        :global_note_template, 3, tracker_id: tracker.id, name: 'Global Note Template name', visibility: 2, enabled: false
+      )
+    end
+
+    scenario 'Disabled global note templates would not be show' do
+      template_list = GlobalNoteTemplate.visible_note_templates_condition(
+        user_id: user.id, project_id: project.id, tracker_id: tracker.id
+      )
+      expect(template_list).to be_empty
+
+      visit_update_issue(user)
+      issue = Issue.last
+      visit "/issues/#{issue.id}"
+      page.find('#content > div:nth-child(1) > a.icon.icon-edit').click
+      sleep(0.2)
+      expect(page).to have_no_selector('a#link_template_issue_notes_dialog')
     end
   end
 


### PR DESCRIPTION
Regarding note templates, we have fixed it so that when "enabled" is set to false (i.e. disabled), the template will no longer be displayed during comment editing. Previously, even when "enabled" was false, the template would still be displayed as a template.