### PR TITLE
support Ruby 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  redmine-plugin: agileware-jp/redmine-plugin@2.3.0
+  redmine-plugin: agileware-jp/redmine-plugin@3.1.0
   plugin-test:
     commands:
       run-tests:
@@ -65,14 +65,11 @@ jobs:
         type: string
       ruby_version:
         type: string
-        default: '2.7'
       db:
         type: enum
         enum: ['mysql', 'pg']
-        default: pg
       db_version:
         type: string
-        default: 'latest-ram'
     executor:
       name: redmine-plugin/ruby-<< parameters.db >>
       ruby_version: << parameters.ruby_version >>
@@ -85,27 +82,37 @@ jobs:
       - redmine-plugin/generate-database_yml
       - redmine-plugin/bundle-install
       - redmine-plugin/rspec
+
+default_context: &default_context
+  context:
+    - lychee-ci-environment
+
 workflows:
   run-tests-workflow:
     jobs:
         - run-tests:
-            name: test on newest versions with PostgreSQL
+            <<: *default_context
+            name: test on supported maximum versions with PostgreSQ
+            redmine_version: $REDMINE_MAX_VERSION
+            ruby_version: $RUBY_MAX_VERSION
             database: pg
-            ruby_version: '2.7'
-            redmine_version: 'latest'
         - run-tests:
-            name: test on oldest versions with MySQL
+            <<: *default_context
+            name: test on supported minimum versions with MySQL
+            redmine_version: $REDMINE_MIN_VERSION
+            ruby_version: $RUBY_MIN_VERSION
             database: mysql
-            ruby_version: '2.6'
-            redmine_version: '4.2.9'
         - rspec:
-            name: RSpec on newest versions with PostgreSQL
-            redmine_version: latest
-            ruby_version: '2.7'
+            <<: *default_context
+            name: RSpec on supported maximum versions with PostgreSQL
+            redmine_version: $REDMINE_MAX_VERSION
+            ruby_version: $RUBY_MAX_VERSION
             db: pg
+            db_version: $POSTGRES_VERSION
         - rspec:
-            name: RSpec on oldest versions with MySQL
-            redmine_version: '4.2.9'
-            ruby_version: '2.6'
+            <<: *default_context
+            name: RSpec on supported minimum versions with MySQL
+            redmine_version: $REDMINE_MIN_VERSION
+            ruby_version: $RUBY_MIN_VERSION
             db: mysql
-            db_version: '5.7-ram'
+            db_version: $MYSQL_VERSION

--- a/spec/features/drag_and_drop_spec.rb
+++ b/spec/features/drag_and_drop_spec.rb
@@ -31,7 +31,9 @@ feature 'Templates can be reorder via drag and drop', js: true do
 
     # change id: 1, 2, 3, 4 to 4, 1, 2, 3
     expect do
-      first_target.drag_to(last_target)
+      Redmine::VERSION::STRING < '4.2' ?
+        page.driver.browser.action.drag_and_drop_by(first_target.native, 0, 90).perform :
+        first_target.drag_to(last_target)
       wait_for_ajax
     end.to change {
              IssueTemplate.order(:id).pluck(:position).to_a
@@ -42,7 +44,9 @@ feature 'Templates can be reorder via drag and drop', js: true do
     last_target = table.find('tr:nth-child(4) > td.buttons > span')
 
     expect do
-      second_target.drag_to(last_target)
+      Redmine::VERSION::STRING < '4.2' ?
+        page.driver.browser.action.drag_and_drop_by(second_target.native, 0, 60).perform :
+        second_target.drag_to(last_target)
       wait_for_ajax
     end.to change {
              IssueTemplate.order(:id).pluck(:position).to_a
@@ -66,7 +70,9 @@ feature 'Templates can be reorder via drag and drop', js: true do
       #--------------------------------------------
       # change position: 1, 2, 3, 4 to 4, 1, 2, 3
       expect do
-        first_target.drag_to(last_target)
+        Redmine::VERSION::STRING < '4.2' ?
+          page.driver.browser.action.drag_and_drop_by(first_target.native, 0, 90).perform :
+          first_target.drag_to(last_target)
         wait_for_ajax
       end.to change {
                NoteTemplate.reorder(:id).pluck(:position).to_a
@@ -79,7 +85,9 @@ feature 'Templates can be reorder via drag and drop', js: true do
       last_target = table.find('tr:nth-child(4) > td.buttons > span')
 
       expect do
-        second_target.drag_to(last_target)
+        Redmine::VERSION::STRING < '4.2' ?
+          page.driver.browser.action.drag_and_drop_by(second_target.native, 0, 60).perform :
+          second_target.drag_to(last_target)
         wait_for_ajax
       end.to change {
                NoteTemplate.reorder(:id).pluck(:position).to_a
@@ -109,7 +117,9 @@ feature 'Templates can be reorder via drag and drop', js: true do
           first_target = table.find("tr:nth-child(#{tr_idx.first}) > td.buttons > span")
           last_target = table.find("tr:nth-child(#{tr_idx.last}) > td.buttons > span")
 
-          first_target.drag_to(last_target)
+          Redmine::VERSION::STRING < '4.2' ?
+            page.driver.browser.action.drag_and_drop_by(first_target.native, 0, 30).perform :
+            first_target.drag_to(last_target)
           wait_for_ajax
           tr_idx.reverse!
         end
@@ -135,7 +145,9 @@ feature 'Templates can be reorder via drag and drop', js: true do
 
     # change id: 1, 2, 3, 4 to 4, 1, 2, 3
     expect do
-      first_target.drag_to(last_target)
+      Redmine::VERSION::STRING < '4.2' ?
+        page.driver.browser.action.drag_and_drop_by(first_target.native, 0, 90).perform :
+        first_target.drag_to(last_target)
       wait_for_ajax
     end.to change {
              GlobalIssueTemplate.reorder(:id).pluck(:position).to_a
@@ -146,7 +158,9 @@ feature 'Templates can be reorder via drag and drop', js: true do
     last_target = table.find('tr:nth-child(4) > td.buttons > span')
 
     expect do
-      second_target.drag_to(last_target)
+      Redmine::VERSION::STRING < '4.2' ?
+        page.driver.browser.action.drag_and_drop_by(second_target.native, 0, 60).perform :
+        second_target.drag_to(last_target)
       wait_for_ajax
     end.to change {
              GlobalIssueTemplate.reorder(:id).pluck(:position).to_a


### PR DESCRIPTION
- Changed ci configuration to support ruby 3.1 version
- fix(add) specs

below automated tests fail only in Redmine 4.1 version because the `drag_to` method does not work correctly.
[spec/features/drag_and_drop_spec.rb](https://github.com/agileware-jp/redmine_issue_templates/commit/ca4829c4e32fcf6da2398c91633f28ee4010daed#diff-9f6ceef34373fa7c8505f9df4655f273bee3f589e8995d7ab187b59befdaa015)

Therefore, we have addressed this so that a similar test can be performed with a different implementation only for the Redmine 4.1 version.
https://github.com/agileware-jp/redmine_issue_templates/commit/ca4829c4e32fcf6da2398c91633f28ee4010daed
