### PR TITLE
Add a dispatchEvent that runs after the selectbox has been changed

### DIFF
--- a/assets/javascripts/issue_templates.js
+++ b/assets/javascripts/issue_templates.js
@@ -381,7 +381,7 @@ ISSUE_TEMPLATE.prototype = {
         let options = document.querySelectorAll('#' + element.id + ' option')
         let filteredOptions = Array.from(options).filter(option => option.text === values[i])
         if (filteredOptions.length > 0) {
-          if (filteredOptions[0].selected == false) { isChangedSelected = true }
+          if (filteredOptions[0].selected === false) { isChangedSelected = true }
           filteredOptions[0].selected = true
         }
       }

--- a/assets/javascripts/issue_templates.js
+++ b/assets/javascripts/issue_templates.js
@@ -376,13 +376,16 @@ ISSUE_TEMPLATE.prototype = {
         values = value
       }
 
+      let isChangedSelected = false;
       for (let i = 0; i < values.length; i++) {
         let options = document.querySelectorAll('#' + element.id + ' option')
         let filteredOptions = Array.from(options).filter(option => option.text === values[i])
         if (filteredOptions.length > 0) {
+          if (filteredOptions[0].selected == false) { isChangedSelected = true }
           filteredOptions[0].selected = true
         }
       }
+      if (isChangedSelected) { element.dispatchEvent(new Event("change")); }
     } else {
       element.value = value
     }


### PR DESCRIPTION
When changing the value of a select box via the "Enable Builtin Field support" feature, the change event is not fired.

Examples of problems caused by this:
1. when the "Enable Builtin Field support" feature is used to update the value of a category, the default person is not applied even if the default person for the category has been determined.
2. customisation of select box values in ViewCustomize plugin does not work when the "Enable Builtin Field support" feature is used to change them Example: https://github.com/onozaty/ redmine-view-customize-scripts/blob/master/examples/0008.change_custom_field_visibility_by_status/example.md
3. redmica_ui_extension plugin has added a function to make the selectbox searchable, but when changing the value of the selectbox with the "Enable Builtin Field support" feature, the display is broken https://github.com/redmica/redmica_ui_extension#1-make-the-selection-box-searchable

Why not fire the change event manually, like `element.dispatchEvent(new Event("change")`, after changing the value of the select box?
There are other places where `document.getElementById('issue_template').dispatchEvent(changeEvent)` is done. https://github.com/agileware-jp/redmine_issue_templates/blob/master/assets/javascripts/issue_templates.js#L420-L423

Thank you.