### PR TITLE
Fix failed specs

### DIFF
--- a/Gemfile.local
+++ b/Gemfile.local
@@ -4,6 +4,7 @@ group :test do
   gem 'factory_bot_rails'
   gem 'launchy'
   gem 'database_cleaner'
+  dependencies.reject! { |i| i.name == 'nokogiri' } # Ensure Nokogiri have new version
 end
 
 # for Debug

--- a/README.md
+++ b/README.md
@@ -167,11 +167,11 @@ Please see .circleci/config.yml for more details.
 % bundle exec rspec -I plugins/redmine_issue_templates/spec --format documentation plugins/redmine_issue_templates/spec/
 ```
 
-By default, `chrome` is used as a webdriver. If you set the environment variable
-`DRIVER` to `headless`, `headless_chrome` will be used.
+By default, `headless` is added as an option. If you set the environment variable
+`HEADLESS` to `0`, `headless` will be removed.
 
 ```bash
-% DRIVER='headless' bundle exec rspec -I plugins/redmine_issue_templates/spec --format documentation plugins/redmine_issue_templates/spec/
+% HEADLESS=0 bundle exec rspec -I plugins/redmine_issue_templates/spec --format documentation plugins/redmine_issue_templates/spec/
 ```
 
 ### Changelog

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ RSpec.configure do |config|
       # In case window size is not specified, Redmine renderes its contents with responsive mode.
       #
       options.add_argument('window-size=1280,800')
-      if ENV['DRIVER'] == 'headless'
+      unless ENV['HEADLESS'] == '0'
         options.add_argument('headless')
         options.add_argument('disable-gpu')
       end


### PR DESCRIPTION
To pass the tests on CI, add `headless` option as default.