### PR TITLE
escape_javascript potentially unsafe values in JS or HTML attributes

### DIFF
--- a/app/views/global_issue_templates/_form.html.erb
+++ b/app/views/global_issue_templates/_form.html.erb
@@ -152,7 +152,7 @@
 <% if builtin_fields_enable %>
 <script type="module">
   TEMPLATE_FIELDS({
-    loadSelectableFieldsPath: "<%= url_for(controller: 'issue_templates', action: 'load_selectable_fields') %>",
+    loadSelectableFieldsPath: "<%= j url_for(controller: 'issue_templates', action: 'load_selectable_fields') %>",
     templateId: "<%= issue_template&.id || '' %>",
     templateType: 'global_issue_template',
     trackerPulldownId: 'global_issue_template_tracker_id',

--- a/app/views/global_issue_templates/index.html.erb
+++ b/app/views/global_issue_templates/index.html.erb
@@ -87,7 +87,7 @@
 <a id='orphaned_template_link' class='icon template_tooltip orphaned_template_link template-help collapsible collapsed'
   title='<%= l(:orphaned_templates) %>'
   data-template-help-target='orphaned_templates'
-  data-url='<%= orphaned_templates_global_issue_templates_path %>'>
+  data-url='<%= j orphaned_templates_global_issue_templates_path %>'>
   <%= l(:orphaned_templates, default: 'Orphaned Templates') %>
 </a>
 

--- a/app/views/issue_templates/_form.html.erb
+++ b/app/views/issue_templates/_form.html.erb
@@ -127,7 +127,7 @@
 <% if builtin_fields_enable %>
 <script type="module">
   TEMPLATE_FIELDS({
-    loadSelectableFieldsPath: "<%= url_for(controller: 'issue_templates', action: 'load_selectable_fields') %>",
+    loadSelectableFieldsPath: "<%= j url_for(controller: 'issue_templates', action: 'load_selectable_fields') %>",
     projectId: "<%= project.id %>",
     templateId: "<%= issue_template&.id || '' %>",
     templateType: 'issue_template',

--- a/app/views/issue_templates/_issue_select_form.html.erb
+++ b/app/views/issue_templates/_issue_select_form.html.erb
@@ -75,17 +75,17 @@
   $(() => {
     //<![CDATA[
     var templateConfig = {
-      pulldownUrl: '<%= pulldown_url %>',
-      isTriggeredBy: '<%= is_triggered_by %>',
-      loadUrl: '<%= url_for(controller: 'issue_templates', action: 'load', project_id: project_id, is_triggered_by: is_triggered_by) %>',
-      shouldReplaced: '<%= setting.should_replaced %>',
-      generalTextYes: '<%=h l(:general_text_Yes) %>',
-      generalTextNo : '<%=h l(:general_text_No) %>',
-      confirmMessage: '<%=h l(:label_template_applied, default: "Issue template is applied. You can revert with click 'Revert' link.") %>'
+      pulldownUrl: '<%= j pulldown_url %>',
+      isTriggeredBy: '<%= j is_triggered_by %>',
+      loadUrl: '<%= j url_for(controller: 'issue_templates', action: 'load', project_id: project_id, is_triggered_by: is_triggered_by) %>',
+      shouldReplaced: '<%= j setting.should_replaced %>',
+      generalTextYes: '<%= l(:general_text_Yes) %>',
+      generalTextNo : '<%= l(:general_text_No) %>',
+      confirmMessage: '<%= j l(:label_template_applied, default: "Issue template is applied. You can revert with click 'Revert' link.") %>'
     }
 
     var templateNS = templateNS || new ISSUE_TEMPLATE(templateConfig)
-    templateNS.isTriggeredBy = '<%= is_triggered_by %>'
+    templateNS.isTriggeredBy = '<%= j is_triggered_by %>'
     templateNS.setPulldown('<%= @issue.tracker.id %>')
 
     document.getElementById('issue_template').addEventListener('change', (event) => {
@@ -95,9 +95,9 @@
 
     // Show dialog
     document.getElementById('link_template_dialog').addEventListener('click', (event) => {
-      let templateListUrl = '<%= url_for(controller: 'issue_templates',
+      let templateListUrl = '<%= j url_for(controller: 'issue_templates',
                                          action:'list_templates', project_id: project_id, issue_tracker_id: @issue.tracker.id) %>'
-      let templateListTitle = '<%= "#{l(:issue_template)}: #{@issue.tracker.name}".html_safe %>'
+      let templateListTitle = '<%= j "#{l(:issue_template)}: #{@issue.tracker.name}" %>'
 
       templateNS.openDialog(templateListUrl, templateListTitle)
     })

--- a/app/views/issue_templates/_note_form.html.erb
+++ b/app/views/issue_templates/_note_form.html.erb
@@ -6,7 +6,7 @@
   project_id = issue&.project_id
   tracker_id = issue&.tracker_id
 %>
-<div id='<%= element_id %>'>
+<div id='<%= j element_id %>'>
   <label for='select_note_template' style='font-weight: bold;'>
     <%=h l(:label_template_for_note, default: 'Template for note') %>
   </label>
@@ -30,11 +30,11 @@
 
 <script type='module'>
   var noteTemplateConfig = {
-    baseElementId: '<%= element_id %>',
-    baseTemplateListUrl: '<%= url_for(controller: 'note_templates', action:'list_templates') %>',
+    baseElementId: '<%= j element_id %>',
+    baseTemplateListUrl: '<%= j url_for(controller: 'note_templates', action:'list_templates') %>',
     baseTrackerId: <%= tracker_id %>,
     baseProjectId: <%= project_id %>,
-    loadNoteTemplateUrl: '<%= load_note_templates_path %>'
+    loadNoteTemplateUrl: '<%= j load_note_templates_path %>'
   }
 
   // let baseElementId = '<%= element_id %>'

--- a/app/views/issue_templates/_template_pulldown.html.erb
+++ b/app/views/issue_templates/_template_pulldown.html.erb
@@ -1,4 +1,4 @@
 <option value=''>---</option>
-<optgroup label='<%=h @tracker.name %>'>
+<optgroup label='<%= j @tracker.name %>'>
   <%= options_for_template_pulldown(grouped_options) %>
 </optgroup>

--- a/app/views/issue_templates/index.html.erb
+++ b/app/views/issue_templates/index.html.erb
@@ -260,7 +260,7 @@
 <a id='orphaned_template_link' class='icon template_tooltip orphaned_template_link template-help collapsible collapsed'
   title='<%= l(:orphaned_templates) %>'
   data-template-help-target='orphaned_templates'
-  data-url='<%= orphaned_templates_project_issue_templates_path %>'>
+  data-url='<%= j orphaned_templates_project_issue_templates_path %>'>
   <%= l(:orphaned_templates, default: 'Orphaned Templates') %>
 </a>
 


### PR DESCRIPTION
- in particular, _template_pulldown.html.erb and _issue_select_form.html.erb allowed code injection via the tracker namem, the latter also did not escape is_triggered_by, which comes from a request parameter