### PR TITLE
Few fixes for global issue template editing

### DIFF
--- a/app/controllers/global_issue_templates_controller.rb
+++ b/app/controllers/global_issue_templates_controller.rb
@@ -2,12 +2,14 @@
 
 # noinspection RubocopInspection
 class GlobalIssueTemplatesController < ApplicationController
-  layout 'base'
+  layout 'admin'
+  self.main_menu = false
+  menu_item :redmine_issue_templates
+
   helper :issues
   helper :issue_templates
   include IssueTemplatesHelper
   include IssueTemplatesCommon
-  menu_item :issues
   before_action :find_object, only: %i[show update destroy]
   before_action :find_project, only: :update
   before_action :require_admin

--- a/app/controllers/global_issue_templates_controller.rb
+++ b/app/controllers/global_issue_templates_controller.rb
@@ -10,7 +10,7 @@ class GlobalIssueTemplatesController < ApplicationController
   menu_item :issues
   before_action :find_object, only: %i[show edit update destroy]
   before_action :find_project, only: %i[edit update]
-  before_action :require_admin, only: %i[index new show], excep: [:preview]
+  before_action :require_admin
 
   #
   # Action for global template : Admin right is required.

--- a/app/controllers/global_issue_templates_controller.rb
+++ b/app/controllers/global_issue_templates_controller.rb
@@ -8,8 +8,8 @@ class GlobalIssueTemplatesController < ApplicationController
   include IssueTemplatesHelper
   include IssueTemplatesCommon
   menu_item :issues
-  before_action :find_object, only: %i[show edit update destroy]
-  before_action :find_project, only: %i[edit update]
+  before_action :find_object, only: %i[show update destroy]
+  before_action :find_project, only: :update
   before_action :require_admin
 
   #
@@ -54,21 +54,6 @@ class GlobalIssueTemplatesController < ApplicationController
     begin
       @global_issue_template.safe_attributes = valid_params
     rescue ActiveRecord::SerializationTypeMismatch, IssueTemplatesCommon::InvalidTemplateFormatError
-      flash[:error] = I18n.t(:builtin_fields_should_be_valid_json, default: 'Please enter a valid JSON fotmat string.')
-      render render_form_params.merge(action: :show)
-      return
-    end
-
-    save_and_flash(:notice_successful_update, :show)
-  end
-
-  def edit
-    # Change from request.post to request.patch for Rails4.
-    return unless request.patch? || request.put?
-
-    begin
-      @global_issue_template.safe_attributes = valid_params
-    rescue ActiveRecord::SerializationTypeMismatch
       flash[:error] = I18n.t(:builtin_fields_should_be_valid_json, default: 'Please enter a valid JSON fotmat string.')
       render render_form_params.merge(action: :show)
       return

--- a/app/views/global_issue_templates/index.html.erb
+++ b/app/views/global_issue_templates/index.html.erb
@@ -1,4 +1,3 @@
-<h2 class='global_issue_template'><%=h "#{l(:global_issue_templates)}" %></h2>
 <%= render partial: 'common/nodata', locals: { trackers: trackers } %>
 <div class='contextual issue_templates'>
   <%= link_to(l(:label_new_templates),
@@ -10,6 +9,7 @@
               { controller: 'settings', action: 'plugin', id: 'redmine_issue_templates' },
               class: 'issue_template icon plugins') %>
 </div>
+<h2 class='global_issue_template'><%=h "#{l(:global_issue_templates)}" %></h2>
 <div style='clear: both;'></div>
 
 <% if template_map.blank? %>

--- a/test/functional/global_issue_templates_controller_test.rb
+++ b/test/functional/global_issue_templates_controller_test.rb
@@ -22,6 +22,33 @@ class GlobalIssueTemplatesControllerTest < Redmine::ControllerTest
     assert_response :success
   end
 
+  def test_should_require_admin
+    @request.session[:user_id] = 2 # Non-admin
+
+    get :index
+    assert_response 403
+
+    get :new
+    assert_response 403
+
+    get :orphaned_templates
+    assert_response 403
+
+    get :show, params: { id: 2 }
+    assert_response 403
+
+    post :preview, params: { global_issue_template: { description: 'Test' } }
+    assert_response 403
+
+    post :create, params: { global_issue_template: { title: 'Global Template title', description: 'test'}}
+    assert_response 403
+
+    assert_no_difference 'GlobalIssueTemplate.count' do
+      delete :destroy, params: { id: 2 }
+      assert_response 403
+    end
+  end
+
   def test_get_index_should_sort_trackers_in_position_order
     [
       ['Feature request', 1],


### PR DESCRIPTION
- use require_admin on all actions
- use admin layout
- removes obsolete `edit` action
- fixes positioning of main headline / contextual div