### PR TITLE
Fix plugin information - author, URL etc. (#43)

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -45,12 +45,12 @@ end
 Redmine::Plugin.register :redmine_issue_templates do
   begin
     name 'Redmine Issue Templates plugin'
-    author 'Akiko Takano'
+    author 'Agileware Inc.'
     description 'Plugin to generate and use issue templates for each project to assist issue creation.'
-    version '0.3.8'
-    author_url 'http://twitter.com/akiko_pusu'
+    version '0.3.10'
+    author_url 'https://agileware.jp/'
     requires_redmine version_or_higher: '4.0'
-    url 'https://github.com/akiko-pusu/redmine_issue_templates'
+    url 'https://github.com/agileware-jp/redmine_issue_templates'
 
     settings partial: 'settings/redmine_issue_templates',
              default: {


### PR DESCRIPTION
Fix plugin information - author, URL etc. (just a backport from commit 456cb4cc1558d77e7e9a301cdab4c1e6b13604b5) I came across this, while upgrading my outdated redmine-instance. 

What about tagging a final 0.3.10?