### PR TITLE
Fix missing Selenium Webdriver error in CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,14 @@ jobs:
           version: << parameters.redmine_version >>
       - redmine-plugin/install-self
       - redmine-plugin/generate-database_yml
+      # NOTE: For Redmine v4.2, it is necessary to upgrade the version of selenium-webdriver to avoid the error:
+      #       "NameError: uninitialized constant Selenium::WebDriver::Chrome::Options".
+      #       This command updates the version of selenium-webdriver in the Gemfile to 3.4.0 or later.
+      - run:
+          name: Update selenium-webdriver version in Gemfile
+          working_directory: redmine
+          command: |
+            sed -i 's/gem "selenium-webdriver".*/gem "selenium-webdriver", ">= 3.4.0"/' Gemfile
       - redmine-plugin/bundle-install
       - redmine-plugin/rspec
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  redmine-plugin: agileware-jp/redmine-plugin@3.5.0
+  redmine-plugin: agileware-jp/redmine-plugin@3.6.0
   plugin-test:
     commands:
       run-tests:

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -10,12 +10,6 @@ group :test do
   gem 'launchy'
   gem 'database_cleaner'
   dependencies.reject! { |i| i.name == 'nokogiri' } # Ensure Nokogiri have new version
-  if Gem.ruby_version < Gem::Version.new('3.0')
-    gem "selenium-webdriver", "<= 4.9.0"
-    gem "webdrivers", require: false
-  else
-    gem "selenium-webdriver", ">= 4.11.0"
-  end
 end
 
 # for Debug

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -10,6 +10,12 @@ group :test do
   gem 'launchy'
   gem 'database_cleaner'
   dependencies.reject! { |i| i.name == 'nokogiri' } # Ensure Nokogiri have new version
+  if Gem.ruby_version < Gem::Version.new('3.0')
+    gem "selenium-webdriver", "<= 4.9.0"
+    gem "webdrivers", require: false
+  else
+    gem "selenium-webdriver", ">= 4.11.0"
+  end
 end
 
 # for Debug

--- a/app/models/global_issue_template.rb
+++ b/app/models/global_issue_template.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class GlobalIssueTemplate < ActiveRecord::Base
+class GlobalIssueTemplate < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   include Redmine::SafeAttributes
   include IssueTemplateCommon
   include AttributeNameMapper

--- a/app/models/global_note_template.rb
+++ b/app/models/global_note_template.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class GlobalNoteTemplate < ActiveRecord::Base
+class GlobalNoteTemplate < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   include Redmine::SafeAttributes
   include AttributeNameMapper
 

--- a/app/models/global_note_template_project.rb
+++ b/app/models/global_note_template_project.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class GlobalNoteTemplateProject < ActiveRecord::Base
+class GlobalNoteTemplateProject < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   belongs_to :project
   belongs_to :global_note_template, optional: true
 end

--- a/app/models/global_note_visible_role.rb
+++ b/app/models/global_note_visible_role.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class GlobalNoteVisibleRole < ActiveRecord::Base
+class GlobalNoteVisibleRole < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   include Redmine::SafeAttributes
 
   safe_attributes 'global_note_template_id', 'role_id'

--- a/app/models/issue_template.rb
+++ b/app/models/issue_template.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class IssueTemplate < ActiveRecord::Base
+class IssueTemplate < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   include Redmine::SafeAttributes
   include IssueTemplateCommon
   include AttributeNameMapper

--- a/app/models/issue_template_setting.rb
+++ b/app/models/issue_template_setting.rb
@@ -1,4 +1,4 @@
-class IssueTemplateSetting < ActiveRecord::Base
+class IssueTemplateSetting < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   include Redmine::SafeAttributes
   belongs_to :project
 

--- a/app/models/note_template.rb
+++ b/app/models/note_template.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NoteTemplate < ActiveRecord::Base
+class NoteTemplate < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   include Redmine::SafeAttributes
   include AttributeNameMapper
 

--- a/app/models/note_visible_role.rb
+++ b/app/models/note_visible_role.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NoteVisibleRole < ActiveRecord::Base
+class NoteVisibleRole < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   include Redmine::SafeAttributes
 
   safe_attributes 'note_template_id', 'role_id'


### PR DESCRIPTION
Story:

```
Failure/Error: log_user(user.login, user.login)
  NameError: uninitialized constant Selenium::WebDriver::Chrome::Options
  # ./plugins/redmine_issue_templates/spec/rails_helper.rb:19
```

This pull request addresses an issue encountered when running Redmine v4.2 with an older version of selenium-webdriver. The older version of selenium-webdriver causes a NameError: uninitialized constant Selenium::WebDriver::Chrome::Options error.

To resolve this issue, we have added a step in the CircleCI configuration to update the selenium-webdriver gem to version 3.4.0 or later in the Gemfile.