### PR TITLE
Fix 'Replace subject and description' option was not applied when core field 'description' was disabled in tracker configuration

### DIFF
--- a/scripts/issue_templates.js
+++ b/scripts/issue_templates.js
@@ -122,7 +122,7 @@ class ISSUE_TEMPLATE {
 
       this.loadedTemplate = obj;
 
-      if (ns.shouldReplaced === 'true' && (issueDescription.value !== '' || issueSubject.value !== '')) {
+      if (ns.shouldReplaced === 'true' && ((issueDescription !== null && issueDescription.value !== '') || issueSubject.value !== '')) {
         if (obj.description !== '' || obj.issue_title !== '') {
           const hideConfirmFlag = ns.hideOverwiteConfirm();
           if (hideConfirmFlag === false) {

--- a/spec/features/issue_template_popup_spec.rb
+++ b/spec/features/issue_template_popup_spec.rb
@@ -116,6 +116,21 @@ feature 'Confirm dialog before overwrite description', js: true do
           wait_for_ajax
           expect(page).not_to have_selector('#issue_template_confirm_to_replace_dialog')
         end
+
+        context 'Tracker without core_fields' do
+          background do
+            tracker.update!(core_fields: [])
+          end
+
+          scenario 'Select template and content is applied.' do
+            visit_new_issue(user)
+            page.driver.browser.manage.add_cookie(name: 'issue_template_confirm_to_replace_hide_dialog', value: '1')
+
+            first_target.select_option
+            wait_for_ajax
+            expect(issue_subject.value).to eq first_template.issue_title
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

Fixed an error when applying issue templates with 'Replace subject and description' enabled on trackers where the standard 'Description' field is disabled.

### Detail

The steps to reproduce the issue are as follows:

1. In the tracker settings, uncheck the 'Description' option under the Standard field.
2. In the 'Template Optional Settings', enable the "Replace subject and description" option.
3. Create an issue template with an 'Issue title' for the tracker from step 1.
4. On the New Issue screen, select the tracker from step 1 and the issue template from step 3.
5. The 'Issue title' from the issue template is not applied to the 'Subject' of the new issue.

### Additional information

```
Environment:
  Redmine version                5.1.3.stable
  Ruby version                   3.2.5-p208 (2024-07-26) [aarch64-linux]
  Rails version                  6.1.7.8
  Environment                    development
  Database adapter               PostgreSQL
  Mailer queue                   ActiveJob::QueueAdapters::AsyncAdapter
  Mailer delivery                smtp
Redmine settings:
  Redmine theme                  Default
SCM:
  Subversion                     1.14.2
  Mercurial                      6.3.2
  Bazaar                         3.3.2
  Git                            2.46.0
  Filesystem                     
Redmine plugins:
  redmine_issue_templates        1.1.2
```