### PR TITLE
Fix "wrong number of arguments in serialize" error in Rails 7.2 to prepare for future releases of Redmine

### DIFF
--- a/app/models/concerns/issue_template_common.rb
+++ b/app/models/concerns/issue_template_common.rb
@@ -43,7 +43,14 @@ module IssueTemplateCommon
     end
 
     # ActiveRecord::SerializationTypeMismatch may be thrown if non hash object is assigned.
-    serialize :builtin_fields_json, Hash
+    #
+    # Passing the class as positional argument has removed in Rails 7.2.
+    # https://edgeguides.rubyonrails.org/7_2_release_notes.html#active-record-removals
+    if Rails.gem_version >= Gem::Version.new('7.2')
+      serialize :builtin_fields_json, type: Hash, coder: YAML
+    else
+      serialize :builtin_fields_json, Hash
+    end
   end
 
   #


### PR DESCRIPTION
This pull request fixes the following error that occurs in Rails 7.2 (Redmine trunk after [r22960](https://www.redmine.org/projects/redmine/repository/svn/revisions/22960)) to prepare for future releases of Redmine.
```
wrong number of arguments (given 2, expected 1) (ArgumentError) /usr/local/bundle/gems/activerecord-7.2.1 /lib/active_record/attribute_methods/serialization.rb:183:in `serialize' /path/to/redmine/plugins/redmine_issue_templates/app/models/concerns/issue_template_common.rb:46:in `block in <module:IssueTemplateCommon>'
```

This error is due to the following incompatible change in Rails 7.2.
```
Remove deprecated support to passing coder and class as second argument to serialize
```
https://edgeguides.rubyonrails.org/7_2_release_notes.html#active-record-removals

Also, a warning about this change was outputting in Redmine trunk (probably after [r22488](https://www.redmine.org/projects/redmine/repository/svn/revisions/22488)).

```
DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be removed in Rails 7.2.

Please pass the class as a keyword argument:

  serialize :builtin_fields_json, type: Hash
 (called from block in <module:IssueTemplateCommon> at /path/to/redmine/plugins/redmine_issue_templates/app/models/concerns/issue_template_common.rb:46)
```

This pull request fixes it so it works in both Redmine 5.1 and the future version based on the instructions in the warning above.

I mainly tested the following points:

* All test pass in Redmine 5.1 and trunk
* The Builtin field support feature works correctly with Redmine 5.1 and trunk (after [r22960](https://www.redmine.org/projects/redmine/repository/svn/revisions/22960))
* After updating Redmine trunk (after [r22960](https://www.redmine.org/projects/redmine/repository/svn/revisions/22960)) from 5.1, an issue template with the setting of the Builtin field saved with Redmine 5.1 or older works correctly