### PR TITLE
Add a workflow to check if issue_templates.js is up to date

### DIFF
--- a/.github/workflows/check-assets-js.yml
+++ b/.github/workflows/check-assets-js.yml
@@ -1,0 +1,37 @@
+name: Check assets/javascripts/issue_templates.js is up-to-date
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check-asset-js:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.16.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild the assets/javascripts/issue_templates.js
+        run: npm run build
+
+      - name: Compare the expected and actual assets/javascripts/issue_templates.js
+        run: |
+          if [ "$(git diff --ignore-space-at-eol assets/javascripts/ | wc -l)" -gt "0" ]; then
+            message="assets/javascripts/issue_templates.js is out of date. Please build and push again according to the \"Build scripts\" section in README.md."
+            echo $message
+
+            # Also add the message to the GitHub step summary
+            echo "## :x: assets/javascripts/issue_templates.js is out of date" >> $GITHUB_STEP_SUMMARY
+            echo $message >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

This pull request proposes a way to keep assets/javascripts/issue_templates.js up to date.

## Background

Currently, when we change any code in the scripts/ directory, we need to run `npm run build` command to rebuild and update the issue_templates.js.

However, as in #103 , the issue_templates.js may be merged into the master branch again while still out-of-date.

## Detail

This pull request adds a workflow that checks if the issue_templates.js is up to date and tells it to build and push again if it is out of date.

I implemented this workflow by referencing [check-dist.yml of the actions/javascript-action](https://github.com/actions/javascript-action/blob/main/.github/workflows/check-dist.yml).

Below are results when tested in my own repository.

Pull request: https://github.com/hidakatsuya/redmine_issue_templates/pull/1
![image](https://github.com/user-attachments/assets/3f9fe9d5-7f96-4562-87a8-4ed1e625705e)

Build results in Actions:
![image](https://github.com/user-attachments/assets/91db8c4c-790e-45eb-ae95-292e402ea7ca)

Build summary in Actions:
![image](https://github.com/user-attachments/assets/23611d6e-03e1-4469-af91-89e67fa7492f)