### PR TITLE
ci: update agileware-jp/redmine-plugin orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  redmine-plugin: agileware-jp/redmine-plugin@3.7.0
+  redmine-plugin: agileware-jp/redmine-plugin@3.8.0
   plugin-test:
     commands:
       run-tests:


### PR DESCRIPTION
No production code changes.

Current master (34537be) + empty commit failure: https://app.circleci.com/pipelines/github/agileware-jp/redmine_issue_templates/169/workflows/5bcc150f-ee57-4261-8050-094081241375

This pull-request fixes it.
