### PR TITLE
Fix error when creating Global Note Template with “Templates visibility: to these roles only”

### DIFF
--- a/app/controllers/global_note_templates_controller.rb
+++ b/app/controllers/global_note_templates_controller.rb
@@ -47,6 +47,12 @@ class GlobalNoteTemplatesController < ApplicationController
     # Workaround in case author id is null
     @global_note_template.author = User.current if @global_note_template.author.blank?
     @global_note_template.safe_attributes = template_params
+    @global_note_template.role_ids =
+      if template_params.key?(:role_ids)
+        template_params[:role_ids]
+      else
+        @global_note_template.global_note_visible_roles.pluck(:role_id)
+      end
 
     save_and_flash(:notice_successful_update, :show)
   end

--- a/app/models/global_note_template.rb
+++ b/app/models/global_note_template.rb
@@ -12,9 +12,9 @@ class GlobalNoteTemplate < (defined?(ApplicationRecord) == 'constant' ? Applicat
                   'tracker_id',
                   'position',
                   'visibility',
-                  'role_ids',
                   'project_ids'
 
+  attr_accessor :role_ids
   validates :role_ids, presence: true, if: :roles?
 
   belongs_to :author, class_name: 'User', inverse_of: false, foreign_key: 'author_id'

--- a/spec/requests/global_note_templates_spec.rb
+++ b/spec/requests/global_note_templates_spec.rb
@@ -38,4 +38,80 @@ RSpec.describe 'Global Note Template', type: :request do
     json = JSON.parse(response.body)
     expect(target_template.name).to eq(json['note_template']['name'])
   end
+
+  it 'create global note template with roles visibility' do
+    login_request(user.login, user.login)
+
+    expected_roles = FactoryBot.create_list(:role, 2)
+    post '/global_note_templates',
+         params: { global_note_template:
+           { tracker_id: tracker.id, name: target_template_name,
+             description: 'Global Note template description', memo: 'Test memo', enabled: 1,
+             visibility: 'roles', role_ids: expected_roles.map(&:id) } }
+    expect(response).to have_http_status(302)
+
+    expect(target_template.visibility).to eq('roles')
+    expect(target_template.roles.count).to eq(2)
+    expect(target_template.roles.map(&:id)).to match_array(expected_roles.map(&:id))
+    expect(GlobalNoteVisibleRole.where(global_note_template_id: nil).count).to eq(0)
+  end
+
+  context 'update global note template' do
+    context 'when visibility changes from open to roles' do
+      it 'changes visibility to roles' do
+        login_request(user.login, user.login)
+        expected_roles = FactoryBot.create_list(:role, 2)
+        target = FactoryBot.create(:global_note_template, { tracker_id: tracker.id, visibility: 'open' })
+        patch '/global_note_templates/' + target.id.to_s,
+              params: { global_note_template:
+                { tracker_id: tracker.id, name: target_template_name,
+                  description: 'Global Note template description', memo: 'Test memo', enabled: 1,
+                  visibility: 'roles', role_ids: expected_roles.map(&:id) } }
+        expect(response).to have_http_status(302)
+
+        expect(target_template.visibility).to eq('roles')
+        expect(target_template.roles.count).to eq(2)
+        expect(target_template.roles.map(&:id)).to match_array(expected_roles.map(&:id))
+        expect(GlobalNoteVisibleRole.where(global_note_template_id: nil).count).to eq(0)
+      end
+    end
+
+    context 'when visibility changes from roles to open' do
+      it 'changes visibility to open' do
+        login_request(user.login, user.login)
+        roles = FactoryBot.create_list(:role, 2)
+        target = FactoryBot.create(:global_note_template, { tracker_id: tracker.id, visibility: 'roles', role_ids: roles.map(&:id) })
+        patch '/global_note_templates/' + target.id.to_s,
+              params: { global_note_template:
+                { tracker_id: tracker.id, name: target_template_name,
+                  description: 'Global Note template description', memo: 'Test memo', enabled: 1,
+                  visibility: 'open' } }
+        expect(response).to have_http_status(302)
+
+        target.reload
+        expect(target.visibility).to eq('open')
+        expect(target.roles.count).to eq(0)
+      end
+    end
+
+    context 'when changes role_ids' do
+      it 'updates roles' do
+        login_request(user.login, user.login)
+        expected_roles = FactoryBot.create_list(:role, 3)
+        target = FactoryBot.create(:global_note_template, { tracker_id: tracker.id, visibility: 'roles', role_ids: FactoryBot.create_list(:role, 2).map(&:id) })
+        patch '/global_note_templates/' + target.id.to_s,
+              params: { global_note_template:
+                { tracker_id: tracker.id, name: target_template_name,
+                  description: 'Global Note template description', memo: 'Test memo', enabled: 1,
+                  visibility: 'roles', role_ids: expected_roles.map(&:id) } }
+        expect(response).to have_http_status(302)
+
+        target.reload
+        expect(target.visibility).to eq('roles')
+        expect(target.roles.count).to eq(3)
+        expect(target.roles.map(&:id)).to match_array(expected_roles.map(&:id))
+        expect(GlobalNoteVisibleRole.where(global_note_template_id: nil).count).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes an issue where creating a new “Global Template for note” with “Templates visibility” set to to these roles only and selecting one or more roles results in the error:
![image](https://github.com/user-attachments/assets/cd6c0cd2-8933-4d55-a082-ac59f7a50d02)

### Detail

#### Reproduction Steps

1. Go to Global Template for note → Add template
1. Change “Templates visibility” to "to these roles only"
1. Select one or more roles
1. Click Create
1. Observe the error

#### Workaround

- Select “to any users” for creation, then change to “to these roles only” after saving → Save succeeds

#### Root Cause

In GlobalNoteTemplate, the role_ids= setter always builds a new global_note_visible_roles association even before saving:
https://github.com/agileware-jp/redmine_issue_templates/blob/1.2.1/app/models/global_note_template.rb#L26

Because the record isn’t saved yet, the associated GlobalNoteVisibleRole fails validation (role_id missing):
https://github.com/agileware-jp/redmine_issue_templates/blob/1.2.1/app/models/global_note_visible_role.rb#L11

#### Changes

- Added request specs for creating and updating Global Templates
- Referenced the implementation of project-level comment templates and applied its behavior as guidance
  - https://github.com/agileware-jp/redmine_issue_templates/blob/1.2.1/app/models/note_template.rb#L9-L13
  - https://github.com/agileware-jp/redmine_issue_templates/blob/1.2.1/app/controllers/note_templates_controller.rb#L51-L56

### Additional information

```
Environment:
  Redmine version                6.0.5.stable
  Ruby version                   3.3.8-p144 (2025-04-09) [x86_64-linux]
  Rails version                  7.2.2.1
  Environment                    development
  Database adapter               PostgreSQL
  Mailer queue                   ActiveJob::QueueAdapters::AsyncAdapter
  Mailer delivery                smtp
Redmine settings:
  Redmine theme                  Default
SCM:
  Subversion                     1.14.2
  Mercurial                      6.3.2
  Git                            2.49.0
  Filesystem                     
Redmine plugins:
  redmine_issue_templates        1.2.1
```