### PR TITLE
Fix template_status-area message overlay blocking button clicks

### DIFF
--- a/assets/stylesheets/issue_templates.css
+++ b/assets/stylesheets/issue_templates.css
@@ -35,6 +35,7 @@ div.issue_template {
     color: #31708f;
     background: #eaf5fb url("../images/lamp.png") no-repeat 3px center;
     border: solid #a7e4fd 1px;
+    pointer-events: none;
 }
 
 #field_information {


### PR DESCRIPTION
### Motivation / Background

This PR prevents the invisible flash message from intercepting clicks on underlying controls. Instead of removing the element from the DOM, it adds a CSS rule ( `pointer-events: none` ) to the message container once it fades out. As a result, even though the element remains present, it no longer blocks mouse or touch events, ensuring the “Create” button (and any other interactive elements) remains fully accessible on all screen sizes.

![image](https://github.com/user-attachments/assets/f1f80446-a03d-417c-8c01-8aeb3993e4f8)

### Additional information

```
Environment:
  Redmine version                6.0.5.stable
  Ruby version                   3.2.8-p263 (2025-03-26) [x86_64-linux]
  Rails version                  7.2.2.1
  Environment                    development
  Database adapter               PostgreSQL
  Mailer queue                   ActiveJob::QueueAdapters::AsyncAdapter
  Mailer delivery                smtp
Redmine settings:
  Redmine theme                  Default
SCM:
  Subversion                     1.14.2
  Mercurial                      6.3.2
  Git                            2.49.0
  Filesystem                     
Redmine plugins:
  redmine_issue_templates        1.2.1
```