### PR TITLE
Fix subdirectory URL duplication issue in templateConfig

### DIFF
--- a/scripts/issue_templates.js
+++ b/scripts/issue_templates.js
@@ -403,7 +403,15 @@ class ISSUE_TEMPLATE {
     const issueProjectId = document.getElementById('issue_project_id')?.value;
     const projectPath = document.querySelector('a.overview')?.href ?? `/projects/${issueProjectId}`;
     const { projectId }  = /projects\/(?<projectId>.+)/.exec(projectPath).groups;
-    axios.post(`${rootPath}watchers/append.js`, {
+    
+    // Ensure the URL is properly constructed for subdirectory deployments
+    let watcherUrl = `${rootPath}watchers/append.js`;
+    if (!watcherUrl.startsWith('http')) {
+      // If rootPath doesn't include protocol, construct relative URL
+      watcherUrl = new URL('watchers/append.js', window.location.origin + window.location.pathname).href;
+    }
+    
+    axios.post(watcherUrl, {
       project_id: projectId,
       watcher: {
         user_ids: values


### PR DESCRIPTION
  When Redmine is deployed in a subdirectory (e.g., https://example.com/sub),
  the pulldownUrl in templateConfig was incorrectly generated with duplicated
  subdirectory paths (e.g., /sub/sub/projects/3/issue_templates/set_pulldown).
  This caused issue templates to not display properly on the new issue form.

  Changes:
  - Use Rails route helpers instead of url_for in pulldown_url method
  - Pass controller context properly to ensure correct URL generation
  - Add fallback mechanism for manual URL construction
  - Remove only_path: true option from ERB templates as it's not needed

  Fixes the template selection dropdown not appearing in subdirectory deployments.

  🤖 Generated with [Claude Code](https://claude.ai/code)