### PR TITLE
Display custom queries above issue templates in sidebar

### DIFF
--- a/lib/issue_templates/issues_hook.rb
+++ b/lib/issue_templates/issues_hook.rb
@@ -35,7 +35,7 @@ module IssueTemplates
       )
     end
 
-    render_on :view_issues_sidebar_planning_bottom, partial: 'issue_templates/issue_template_link'
+    render_on :view_issues_sidebar_queries_bottom, partial: 'issue_templates/issue_template_link'
 
     private
 


### PR DESCRIPTION
This PR adjusts the display order of sections in the issue list sidebar to prioritize "Custom queries" for better accessibility.

## Reason for change

Custom queries are generally used more frequently than issue template links. Placing the custom queries list at the top of the sidebar improves the user workflow by providing more immediate access.

## Implementation

The view hook for rendering the template sections was changed from `:view_issues_sidebar_planning_bottom` to `:view_issues_sidebar_queries_bottom`.

This relocates the "Issue template" and "Template for note" sections to appear directly below the "Custom queries" section, as shown below.

**Before:**

<img width="581" height="592" alt="before" src="https://github.com/user-attachments/assets/14f02a0c-0b07-4d18-9548-75418516e47f" />


**After:**

<img width="581" height="592" alt="after" src="https://github.com/user-attachments/assets/c5bd14f2-3892-4103-9144-6b914a54a08c" />
