### PR TITLE
Fix test failure caused by NoMethodError: undefined method 'fixture_path='

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,13 @@ require 'selenium-webdriver'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  config.fixture_path = "#{::Rails.root}/test/fixtures"
+  # TestFixtures#fixture_path was removed in Rails 7.2, use fixture_paths instead.
+  if config.respond_to?(:fixture_paths)
+    config.fixture_paths = ["#{::Rails.root}/test/fixtures"]
+  else
+    config.fixture_path = "#{::Rails.root}/test/fixtures"
+  end
+
   config.include FactoryBot::Syntax::Methods
 
   config.before :suite do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,12 @@ SimpleCov.coverage_dir('coverage/redmine_issue_templates_spec')
 SimpleCov.start 'rails'
 
 RSpec.configure do |config|
-  config.fixture_path = "#{::Rails.root}/test/fixtures"
+  # TestFixtures#fixture_path was removed in Rails 7.2, use fixture_paths instead.
+  if config.respond_to?(:fixture_paths)
+    config.fixture_paths = ["#{::Rails.root}/test/fixtures"]
+  else
+    config.fixture_path = "#{::Rails.root}/test/fixtures"
+  end
   config.use_transactional_fixtures = false
   config.infer_spec_type_from_file_location!
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
This pull request addresses a test failure in rspec caused by `NoMethodError: undefined method 'fixture_path='`.

https://app.circleci.com/pipelines/github/hidakatsuya/redmine_issue_templates/3/workflows/0b7a45a5-d9c9-419f-b203-45a9cb3a67d5/jobs/22
```
NoMethodError:
  undefined method `fixture_path=' for #<RSpec::Core::Configuration:0x00007fcec664f298>
# ./plugins/redmine_issue_templates/spec/spec_helper.rb:11:in `block in <top (required)>'
# ./plugins/redmine_issue_templates/spec/spec_helper.rb:10:in `<top (required)>'
# ./plugins/redmine_issue_templates/spec/requests/global_note_templates_spec.rb:3:in `require_relative'
# ./plugins/redmine_issue_templates/spec/requests/global_note_templates_spec.rb:3:in `<top (required)>'
```

In Rails 7.1, `TestFixture#fixture_paths=` was introduced as a replacement for `fixture_path=`, and in Rails 7.2, `fixture_path=` was removed.
https://github.com/rails/rails/pull/47675