### PR TITLE
Fix test_update_template_with_empty_title failures in IssueTemplatesControllerTest and GlobalIssueTemplatesControllerTest

### DIFF
--- a/test/functional/global_issue_templates_controller_test.rb
+++ b/test/functional/global_issue_templates_controller_test.rb
@@ -57,7 +57,7 @@ class GlobalIssueTemplatesControllerTest < Redmine::ControllerTest
     assert_not_equal '', global_issue_template.title
 
     # render :show
-    assert_select 'h2.global_issue_template', "#{l(:global_issue_templates)}: ##{global_issue_template.id}"
+    assert_select 'h2.global_issue_template', text: /#{l(:global_issue_templates)}: ##{global_issue_template.id}/
     # Error message should be displayed.
     assert_select 'div#errorExplanation', { count: 1, text: /Template name cannot be blank/ }, @response.body.to_s
   end

--- a/test/functional/issue_templates_controller_test.rb
+++ b/test/functional/issue_templates_controller_test.rb
@@ -147,7 +147,7 @@ class IssueTemplatesControllerTest < Redmine::ControllerTest
     assert_equal(num, IssueTemplate.count)
 
     # render :show
-    assert_select 'h2.issue_template', "#{l(:issue_templates)}: #2"
+    assert_select 'h2.issue_template', text: /#{l(:issue_templates)}: #2/
     assert_select 'div#edit-issue_template'
     # Error message should be displayed.
     assert_select 'div#errorExplanation', { count: 1, text: /Template name cannot be blank/ }, @response.body.to_s


### PR DESCRIPTION
This pull request fixes the following failing tests:

https://app.circleci.com/pipelines/github/hidakatsuya/redmine_issue_templates/3/workflows/0b7a45a5-d9c9-419f-b203-45a9cb3a67d5/jobs/19

```
Failure:
IssueTemplatesControllerTest#test_update_template_with_empty_title [plugins/redmine_issue_templates/test/functional/issue_templates_controller_test.rb:150]:
Expected: "Issue templates: #2"
  Actual: "Issue templates: #2 RA".
Expected 0 to be >= 1.
...
```

```
Failure:
GlobalIssueTemplatesControllerTest#test_update_template_with_empty_title [plugins/redmine_issue_templates/test/functional/global_issue_templates_controller_test.rb:60]:
--- expected
+++ actual
@@ -1 +1 @@
-"Global Issue Templates: #2"
+"Global Issue Templates: #2 RA"
.
Expected 0 to be >= 1.
...
```

These failures appear to be caused by the change introduced in [Redmine #42623](https://www.redmine.org/issues/42623)

In these tests, it is sufficient to check for the presence of the `h2` tag. Therefore, the assertions have been updated to use partial matches instead of exact text matches. This also keeps the tests compatible with Redmine versions before  [Redmine #42623](https://www.redmine.org/issues/42623).

With #136 and this pull request, all tests passed on my forked repository except for *"RSpec on supported maximum versions with PostgreSQL"*. See the results here:
https://app.circleci.com/pipelines/github/hidakatsuya/redmine_issue_templates/15/workflows/68ff4387-0f37-437e-a1da-935ed330ba5f
