### PR TITLE
Load legacy-icons-compat.css to keep raster icons visible on Redmine 7.0 or later

### DIFF
--- a/lib/issue_templates/issues_hook.rb
+++ b/lib/issue_templates/issues_hook.rb
@@ -13,9 +13,17 @@ module IssueTemplates
     ACTIONS = %('new' 'update_form' 'create', 'show').freeze
 
     def view_layouts_base_html_head(context = {})
-      o = stylesheet_link_tag('issue_templates', plugin: 'redmine_issue_templates')
-      o << redmine_issue_template_javascript_include_tag if need_template_js?(context[:controller])
-      o
+      safe_join([
+        # In Redmine trunk (toward version 7.0), legacy raster icon styles have been
+        # extracted from application.css into legacy-icons-compat.css and are no longer
+        # loaded by default.
+        # https://www.redmine.org/issues/43206
+        #
+        # Load legacy-icons-compat.css so that raster icons can continue to be displayed.
+        redmine_legacy_icons_compat_stylesheet_link_tag,
+        stylesheet_link_tag('issue_templates', plugin: 'redmine_issue_templates'),
+        need_template_js?(context[:controller]) ? redmine_issue_template_javascript_include_tag : nil
+      ])
     end
 
     def view_issues_form_details_top(context = {})
@@ -104,6 +112,12 @@ module IssueTemplates
         javascript_include_tag(source, type: :module)
       else
         javascript_include_tag(:issue_templates, plugin: :redmine_issue_templates, type: :module)
+      end
+    end
+
+    def redmine_legacy_icons_compat_stylesheet_link_tag
+      if Rails.root.join('app', 'assets', 'stylesheets', 'legacy-icons-compat.css').exist?
+        stylesheet_link_tag('legacy-icons-compat.css', media: 'all')
       end
     end
   end


### PR DESCRIPTION
## Background / Purpose

In Redmine 7.0 and later, the legacy raster icon styles were moved from application.css to legacy-icons-compat.css and are no longer loaded by default.
https://www.redmine.org/issues/43206

Therefore, since [r24029](https://www.redmine.org/projects/redmine/repository/svn/revisions/24029)￼ in Redmine trunk, the icons in this plugin have not been displayed correctly.

<img width="2180" height="1312" alt="trunk-before1" src="https://github.com/user-attachments/assets/68919996-503a-44ed-8940-0f846c40c50c" />

<img width="2180" height="1312" alt="trunk-before2" src="https://github.com/user-attachments/assets/18cfe054-9b41-4bc9-a550-d9fd6146a48d" />

At the same time, since this plugin uses many icons, migrating all of them to SVG icons is expected to take some time.

Therefore, this pull request loads legacy-icons-compat.css to keep existing raster icons displayed correctly in future versions of Redmine, while allowing the plugin to gradually migrate to SVG icons.

## Details

* legacy-icons-compat.css is loaded only if the file exists (i.e., on Redmine 7.0 and later).
* Confirmed that all icons are displayed correctly on Redmine 5.1, 6.1, and trunk.
* Confirmed that all tests, except those already failing on master, passed. [CircleCI build](https://app.circleci.com/pipelines/github/hidakatsuya/redmine_issue_templates/24/workflows/46b87a9b-5601-46f6-afcb-80a73951e75f)￼

## Screenshots

### 5.1

<details><summary>Details</summary>
<p>

<img width="2180" height="1312" alt="5 1-1" src="https://github.com/user-attachments/assets/167ccaee-7b91-4b64-bd8f-ab120e2196fa" />

<img width="2180" height="1312" alt="5 1-2" src="https://github.com/user-attachments/assets/3047e728-a184-4e35-a7b5-0276138065de" />

<img width="2180" height="1636" alt="5 1-3" src="https://github.com/user-attachments/assets/289cd95d-500d-49e4-b87d-0810e864407f" />

<img width="2180" height="1312" alt="5 1-4" src="https://github.com/user-attachments/assets/4b7e819d-e1e3-4510-b037-702c8c8c5b91" />

<img width="2180" height="1312" alt="5 1-5" src="https://github.com/user-attachments/assets/2117165c-57b1-4195-be50-714c8d675b2a" />

</p>
</details> 


### 6.1

<details><summary>Details</summary>
<p>

<img width="2180" height="1312" alt="6 1-1" src="https://github.com/user-attachments/assets/6b1be465-0e4e-4e81-80d2-287045db5cef" />

<img width="2180" height="1312" alt="6 1-2" src="https://github.com/user-attachments/assets/27c2e34f-432d-46f2-8414-821c557a1ef0" />

<img width="2180" height="1698" alt="6 1-3" src="https://github.com/user-attachments/assets/8940b0dc-6d23-4cd6-9675-bf03edaa2b41" />

<img width="2180" height="1312" alt="6 1-4" src="https://github.com/user-attachments/assets/3de9708e-cb3a-4c95-b661-266afa82b7e2" />

<img width="2180" height="1312" alt="6 1-5" src="https://github.com/user-attachments/assets/d04006e6-3dea-4a87-849d-7aa2d47d3469" />

</p>
</details> 

### trunk (r24116)

<details><summary>Details</summary>
<p>

<img width="2178" height="1312" alt="trunk-1" src="https://github.com/user-attachments/assets/1de2cab0-d10c-4c2a-b944-7ac1e0943f0f" />

<img width="2180" height="1312" alt="trunk-2" src="https://github.com/user-attachments/assets/a79abd3e-f112-4e02-ab51-f10f73669000" />

<img width="2180" height="1312" alt="trunk-3" src="https://github.com/user-attachments/assets/ad1a6661-104d-4b0f-8be7-9999c2f6ad86" />

<img width="2180" height="1312" alt="trunk-4" src="https://github.com/user-attachments/assets/a243dd74-9996-4a03-b3ee-288e83826cfa" />

</p>
</details> 