### PR TITLE
refactor(GlobalNoteTemplateProject): remove because it is unused

### DIFF
--- a/app/models/global_note_template_project.rb
+++ b/app/models/global_note_template_project.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class GlobalNoteTemplateProject < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
-  belongs_to :project
-  belongs_to :global_note_template, optional: true
-end


### PR DESCRIPTION
When #65, Project and GlobalNoteTemplate relations uses `has_and_belongs_to_many`. They does not use GlobalNoteTemplateProject.
