### PR TITLE
fix: テンプレートポップアップを画面内に収めスクロール可能にする

### DIFF
--- a/assets/stylesheets/issue_templates.css
+++ b/assets/stylesheets/issue_templates.css
@@ -321,6 +321,8 @@ a.icon-help:hover .tooltip-area {
     width: 60%;
     max-width: 860px;
     min-width: 520px;
+    max-height: calc(100vh - 200px);
+    overflow-y: auto;
     position: relative;
     transition: all 5s ease-in-out;
 }


### PR DESCRIPTION
## 概要

コメント用テンプレート（ノートテンプレート）および課題テンプレートのダイアログで、テンプレート数が多いとポップアップがビューポートを超えて縦に伸び、×ボタンやリスト上部にアクセスできず、リストをスクロールもできなくなる問題を修正します。

## 原因

ポップアップ共通クラス `.popup` に高さの上限(`max-height`)も `overflow` も指定されていなかったため、`.filtered_templates_list` の中身が増えると `.popup` 自体が画面外まで伸びていました。

`.popup .content { max-height:50%; overflow:auto }` というルールは存在しますが、実際の HTML に `.content` クラスを持つ要素が無く効いていませんでした。

## 修正内容

`.popup` に以下を追加し、ポップアップを画面内に収めて内部スクロールできるようにします。

```css
max-height: calc(100vh - 200px);  /* margin:100px auto を考慮 */
overflow-y: auto;
```

共通クラスへの追加のため、以下の両ダイアログに適用されます。

- コメント用テンプレートダイアログ（`_note_form.html.erb`）
- 課題テンプレートダイアログ（`_issue_select_form.html.erb`）

上書き確認ダイアログ（`.popup.small`）は中身が固定で小さいため影響ありません。

## 動作確認

ノートテンプレートを多数登録した状態でコメント欄のテンプレートダイアログを開いて確認しました。

- `.popup` の computed style に `max-height: 600px`（=`100vh - 200px`）、`overflow-y: auto` が適用される
- 中身が `max-height` を超えてもポップアップは画面内（viewport 800px のとき top:100 / bottom:700）に収まる
- ポップアップ内で最下部までスクロールでき、末尾のテンプレートまで到達できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)